### PR TITLE
 feat: Prod 환경 Terraform 구성 추가

### DIFF
--- a/terraform/envs/prod/.terraform.lock.hcl
+++ b/terraform/envs/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/envs/prod/alb.tf
+++ b/terraform/envs/prod/alb.tf
@@ -1,0 +1,47 @@
+resource "aws_lb" "backend" {
+  name               = "qfeed-prod-alb-backend"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+
+  subnets = [
+    data.aws_subnet.public_a.id,
+    aws_subnet.public_c.id,
+  ]
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-alb-backend" })
+}
+
+resource "aws_lb_target_group" "backend" {
+  name     = "qfeed-prod-tg-backend"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = data.aws_vpc.prod.id
+
+  health_check {
+    enabled             = true
+    path                = "/actuator/health"
+    port                = "8081"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-tg-backend" })
+}
+
+resource "aws_lb_listener" "backend" {
+  load_balancer_arn = aws_lb.backend.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-listener-backend" })
+}

--- a/terraform/envs/prod/compute.tf
+++ b/terraform/envs/prod/compute.tf
@@ -1,0 +1,248 @@
+# =============================================================================
+# 공통 user_data (Docker + SSM Agent + AWS CLI)
+# =============================================================================
+
+locals {
+  base_user_data = <<-USERDATA
+#!/bin/bash
+set -euxo pipefail
+
+# Docker
+apt-get update -y
+apt-get install -y ca-certificates curl unzip
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+usermod -aG docker ubuntu
+systemctl enable docker
+systemctl start docker
+
+# SSM Agent
+cd /tmp
+wget -q https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_arm64/amazon-ssm-agent.deb
+dpkg -i amazon-ssm-agent.deb
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
+
+# AWS CLI v2 (ARM64)
+cd /tmp
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+unzip -qo awscliv2.zip
+./aws/install
+rm -rf awscliv2.zip aws
+USERDATA
+}
+
+# =============================================================================
+# Backend EC2 (ASG 2~4)
+# =============================================================================
+
+resource "aws_launch_template" "backend" {
+  name          = "qfeed-prod-lt-backend"
+  image_id      = var.ami_id
+  instance_type = "t4g.small"
+  key_name      = var.key_pair_name
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ec2_backend.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.backend.id]
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  user_data = base64encode(local.base_user_data)
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, { Name = "qfeed-prod-ec2-backend" })
+  }
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(local.common_tags, { Name = "qfeed-prod-ec2-backend" })
+  }
+  tags = merge(local.common_tags, { Name = "qfeed-prod-lt-backend" })
+}
+
+resource "aws_autoscaling_group" "backend" {
+  name                = "qfeed-prod-asg-backend"
+  min_size            = 2
+  max_size            = 4
+  desired_capacity    = 2
+  vpc_zone_identifier = [aws_subnet.private_app_a.id]
+  target_group_arns   = [aws_lb_target_group.backend.arn]
+
+  launch_template {
+    id      = aws_launch_template.backend.id
+    version = "$Latest"
+  }
+
+  health_check_type         = "EC2"
+  health_check_grace_period = 300
+
+  dynamic "tag" {
+    for_each = merge(local.common_tags, { Name = "qfeed-prod-ec2-backend" })
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+
+# =============================================================================
+# AI EC2 (ASG 1)
+# =============================================================================
+
+resource "aws_launch_template" "ai" {
+  name          = "qfeed-prod-lt-ai"
+  image_id      = var.ami_id
+  instance_type = "t4g.small"
+  key_name      = var.key_pair_name
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ec2_ai.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.ai.id]
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  user_data = base64encode(local.base_user_data)
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, { Name = "qfeed-prod-ec2-ai" })
+  }
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(local.common_tags, { Name = "qfeed-prod-ec2-ai" })
+  }
+  tags = merge(local.common_tags, { Name = "qfeed-prod-lt-ai" })
+}
+
+resource "aws_autoscaling_group" "ai" {
+  name                = "qfeed-prod-asg-ai"
+  min_size            = 1
+  max_size            = 1
+  desired_capacity    = 1
+  vpc_zone_identifier = [aws_subnet.private_app_a.id]
+
+  launch_template {
+    id      = aws_launch_template.ai.id
+    version = "$Latest"
+  }
+
+  health_check_type         = "EC2"
+  health_check_grace_period = 300
+
+  dynamic "tag" {
+    for_each = merge(local.common_tags, { Name = "qfeed-prod-ec2-ai" })
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+
+# =============================================================================
+# Redis EC2 (고정 1대, user_data에서 Redis 컨테이너 기동)
+# =============================================================================
+
+resource "aws_launch_template" "redis" {
+  name          = "qfeed-prod-lt-redis"
+  image_id      = var.ami_id
+  instance_type = "t4g.micro"
+  key_name      = var.key_pair_name
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ec2_redis.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.redis.id]
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  user_data = base64encode(<<-USERDATA
+${local.base_user_data}
+
+# Redis 컨테이너 기동
+REDIS_PASSWORD=$(aws ssm get-parameter \
+  --region ap-northeast-2 \
+  --name "/qfeed/prod/be/REDIS_PASSWORD" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text)
+
+docker run -d \
+  --name redis \
+  --network host \
+  --restart unless-stopped \
+  --log-driver json-file \
+  --log-opt max-size=10m \
+  --log-opt max-file=3 \
+  -v redis-data:/data \
+  redis:7-alpine \
+  redis-server \
+    --appendonly yes \
+    --maxmemory 512mb \
+    --maxmemory-policy allkeys-lru \
+    --requirepass "$REDIS_PASSWORD" \
+    --bind 0.0.0.0
+USERDATA
+  )
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, { Name = "qfeed-prod-ec2-redis" })
+  }
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(local.common_tags, { Name = "qfeed-prod-ec2-redis" })
+  }
+  tags = merge(local.common_tags, { Name = "qfeed-prod-lt-redis" })
+}
+
+resource "aws_autoscaling_group" "redis" {
+  name                = "qfeed-prod-asg-redis"
+  min_size            = 1
+  max_size            = 1
+  desired_capacity    = 1
+  vpc_zone_identifier = [aws_subnet.private_app_a.id]
+
+  launch_template {
+    id      = aws_launch_template.redis.id
+    version = "$Latest"
+  }
+
+  health_check_type         = "EC2"
+  health_check_grace_period = 300
+
+  dynamic "tag" {
+    for_each = merge(local.common_tags, { Name = "qfeed-prod-ec2-redis" })
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}

--- a/terraform/envs/prod/data.tf
+++ b/terraform/envs/prod/data.tf
@@ -1,0 +1,26 @@
+# AWS 계정 정보
+data "aws_caller_identity" "current" {}
+
+# 기존 리소스 참조
+
+data "aws_vpc" "prod" {
+  id = "vpc-0cd05ba717f09a29e"
+}
+
+data "aws_subnet" "public_a" {
+  id = "subnet-05db546c3af102bc5"
+}
+
+data "aws_route_table" "public" {
+  route_table_id = "rtb-075c74888f471c953"
+}
+
+# RDS 마스터 비밀번호 (SSM Parameter Store SecureString)
+data "aws_ssm_parameter" "db_password" {
+  name = "/qfeed/prod/db-password"
+}
+
+# OIDC Provider (계정에 1개, dev에서 생성 완료)
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/terraform/envs/prod/iam.tf
+++ b/terraform/envs/prod/iam.tf
@@ -1,0 +1,420 @@
+# =============================================================================
+# Backend EC2 IAM Role
+# =============================================================================
+
+resource "aws_iam_role" "ec2_backend" {
+  name = "qfeed-prod-role-ec2-backend"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-role-ec2-backend" })
+}
+
+resource "aws_iam_role_policy" "backend_ssm_params" {
+  name = "qfeed-prod-policy-backend-ssm"
+  role = aws_iam_role.ec2_backend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath"
+        ]
+        Resource = "arn:aws:ssm:ap-northeast-2:*:parameter/qfeed/prod/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "backend_ecr" {
+  name = "qfeed-prod-policy-backend-ecr"
+  role = aws_iam_role.ec2_backend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "backend_s3" {
+  name = "qfeed-prod-policy-backend-s3"
+  role = aws_iam_role.ec2_backend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::qfeed-prod-s3-*",
+          "arn:aws:s3:::qfeed-prod-s3-*/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "backend_cloudwatch_logs" {
+  name = "qfeed-prod-policy-backend-cloudwatch-logs"
+  role = aws_iam_role.ec2_backend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:ap-northeast-2:*:log-group:/qfeed/prod/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "backend_ssm_managed" {
+  role       = aws_iam_role.ec2_backend.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_backend" {
+  name = "qfeed-prod-profile-ec2-backend"
+  role = aws_iam_role.ec2_backend.name
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-profile-ec2-backend" })
+}
+
+# =============================================================================
+# AI EC2 IAM Role
+# =============================================================================
+
+resource "aws_iam_role" "ec2_ai" {
+  name = "qfeed-prod-role-ec2-ai"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-role-ec2-ai" })
+}
+
+resource "aws_iam_role_policy" "ai_ssm_params" {
+  name = "qfeed-prod-policy-ai-ssm"
+  role = aws_iam_role.ec2_ai.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath"
+        ]
+        Resource = "arn:aws:ssm:ap-northeast-2:*:parameter/qfeed/prod/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ai_ecr" {
+  name = "qfeed-prod-policy-ai-ecr"
+  role = aws_iam_role.ec2_ai.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ai_s3" {
+  name = "qfeed-prod-policy-ai-s3"
+  role = aws_iam_role.ec2_ai.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::qfeed-prod-s3-*",
+          "arn:aws:s3:::qfeed-prod-s3-*/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ai_cloudwatch_logs" {
+  name = "qfeed-prod-policy-ai-cloudwatch-logs"
+  role = aws_iam_role.ec2_ai.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:ap-northeast-2:*:log-group:/qfeed/prod/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ai_ssm_managed" {
+  role       = aws_iam_role.ec2_ai.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_ai" {
+  name = "qfeed-prod-profile-ec2-ai"
+  role = aws_iam_role.ec2_ai.name
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-profile-ec2-ai" })
+}
+
+# =============================================================================
+# Redis EC2 IAM Role (SSM params + SSM Session Manager)
+# =============================================================================
+
+resource "aws_iam_role" "ec2_redis" {
+  name = "qfeed-prod-role-ec2-redis"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-role-ec2-redis" })
+}
+
+resource "aws_iam_role_policy" "redis_ssm_params" {
+  name = "qfeed-prod-policy-redis-ssm"
+  role = aws_iam_role.ec2_redis.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters"
+        ]
+        Resource = "arn:aws:ssm:ap-northeast-2:*:parameter/qfeed/prod/be/REDIS_PASSWORD"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "redis_ssm_managed" {
+  role       = aws_iam_role.ec2_redis.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_redis" {
+  name = "qfeed-prod-profile-ec2-redis"
+  role = aws_iam_role.ec2_redis.name
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-profile-ec2-redis" })
+}
+
+# =============================================================================
+# GitHub Actions IAM Role (Prod 전용)
+# =============================================================================
+
+resource "aws_iam_role" "github_actions" {
+  name = "qfeed-prod-role-github-actions"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:100-hours-a-week/17-JinyUs-Q-Feed-BE:ref:refs/heads/main",
+              "repo:100-hours-a-week/17-JinyUs-Q-Feed-AI:ref:refs/heads/main",
+            ]
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-role-github-actions" })
+}
+
+# GitHub Actions - ECR Push (공용 ECR repo 참조)
+
+resource "aws_iam_role_policy" "github_actions_ecr" {
+  name = "qfeed-prod-policy-github-actions-ecr"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:DescribeImages",
+          "ecr:CompleteLayerUpload",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ]
+        Resource = [
+          "arn:aws:ecr:ap-northeast-2:${data.aws_caller_identity.current.account_id}:repository/qfeed-ecr-backend",
+          "arn:aws:ecr:ap-northeast-2:${data.aws_caller_identity.current.account_id}:repository/qfeed-ecr-ai"
+        ]
+      }
+    ]
+  })
+}
+
+# GitHub Actions - SSM Run Command (prod EC2만)
+
+resource "aws_iam_role_policy" "github_actions_ssm" {
+  name = "qfeed-prod-policy-github-actions-ssm"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ssm:SendCommand"
+        Resource = "arn:aws:ssm:ap-northeast-2::document/AWS-RunShellScript"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ssm:SendCommand"
+        Resource = "arn:aws:ec2:ap-northeast-2:*:instance/*"
+        Condition = {
+          StringEquals = {
+            "ssm:resourceTag/Project"     = "qfeed"
+            "ssm:resourceTag/Environment" = "prod"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetCommandInvocation",
+          "ssm:ListCommandInvocations"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# GitHub Actions - S3 (prod 버킷)
+
+resource "aws_iam_role_policy" "github_actions_s3" {
+  name = "qfeed-prod-policy-github-actions-s3"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = [
+          "arn:aws:s3:::qfeed-prod-s3-*",
+          "arn:aws:s3:::qfeed-prod-s3-*/*"
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.0"
+
+  backend "s3" {
+    bucket       = "qfeed-infra-s3-tfstate"
+    key          = "envs/prod/terraform.tfstate"
+    region       = "ap-northeast-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  common_tags = {
+    Environment = "prod"
+    Project     = "qfeed"
+    ManagedBy   = "terraform"
+  }
+}

--- a/terraform/envs/prod/network.tf
+++ b/terraform/envs/prod/network.tf
@@ -1,0 +1,98 @@
+# =============================================================================
+# Public Subnet C (ALB에 최소 2 AZ 필요, AZ-a는 기존 data source 사용)
+# =============================================================================
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = data.aws_vpc.prod.id
+  cidr_block              = "10.0.48.0/20"
+  availability_zone       = "ap-northeast-2c"
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-subnet-public-c" })
+}
+
+resource "aws_route_table_association" "public_c" {
+  subnet_id      = aws_subnet.public_c.id
+  route_table_id = data.aws_route_table.public.id
+}
+
+# =============================================================================
+# NAT Gateway (private subnet → 인터넷)
+# =============================================================================
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-eip-nat" })
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = data.aws_subnet.public_a.id
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-natgw" })
+
+  depends_on = [aws_eip.nat]
+}
+
+# =============================================================================
+# Private-App Subnet (EC2: Backend, AI, Redis)
+# =============================================================================
+
+resource "aws_subnet" "private_app_a" {
+  vpc_id            = data.aws_vpc.prod.id
+  cidr_block        = "10.0.16.0/20"
+  availability_zone = "ap-northeast-2a"
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-subnet-private-app-a" })
+}
+
+# =============================================================================
+# Private-Data Subnets (RDS — subnet group에 최소 2 AZ 필요)
+# =============================================================================
+
+resource "aws_subnet" "private_data_a" {
+  vpc_id            = data.aws_vpc.prod.id
+  cidr_block        = "10.0.32.0/20"
+  availability_zone = "ap-northeast-2a"
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-subnet-private-data-a" })
+}
+
+resource "aws_subnet" "private_data_c" {
+  vpc_id            = data.aws_vpc.prod.id
+  cidr_block        = "10.0.80.0/20"
+  availability_zone = "ap-northeast-2c"
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-subnet-private-data-c" })
+}
+
+# =============================================================================
+# Private Route Table (NAT GW 경유)
+# =============================================================================
+
+resource "aws_route_table" "private" {
+  vpc_id = data.aws_vpc.prod.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-rt-private" })
+}
+
+resource "aws_route_table_association" "private_app_a" {
+  subnet_id      = aws_subnet.private_app_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_data_a" {
+  subnet_id      = aws_subnet.private_data_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_data_c" {
+  subnet_id      = aws_subnet.private_data_c.id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/envs/prod/outputs.tf
+++ b/terraform/envs/prod/outputs.tf
@@ -1,0 +1,31 @@
+output "alb_dns_name" {
+  value = aws_lb.backend.dns_name
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.postgres.endpoint
+}
+
+output "rds_address" {
+  value = aws_db_instance.postgres.address
+}
+
+output "nat_gateway_public_ip" {
+  value = aws_eip.nat.public_ip
+}
+
+output "backend_asg_name" {
+  value = aws_autoscaling_group.backend.name
+}
+
+output "ai_asg_name" {
+  value = aws_autoscaling_group.ai.name
+}
+
+output "redis_asg_name" {
+  value = aws_autoscaling_group.redis.name
+}
+
+output "github_actions_role_arn" {
+  value = aws_iam_role.github_actions.arn
+}

--- a/terraform/envs/prod/rds.tf
+++ b/terraform/envs/prod/rds.tf
@@ -1,0 +1,40 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "qfeed-prod-rds-subnetgroup"
+  subnet_ids = [aws_subnet.private_data_a.id, aws_subnet.private_data_c.id]
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-rds-subnetgroup" })
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier                  = "qfeed-prod-rds-postgres"
+  engine                      = "postgres"
+  engine_version              = "18.1"
+  allow_major_version_upgrade = true
+  apply_immediately           = false
+  instance_class              = "db.t4g.small"
+  availability_zone           = "ap-northeast-2a"
+
+  allocated_storage = 20
+  storage_type      = "gp3"
+
+  db_name  = "qfeedproddb"
+  username = var.db_username
+  password = data.aws_ssm_parameter.db_password.value
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  publicly_accessible     = false
+  storage_encrypted       = true
+  backup_retention_period = 7
+  multi_az                = false
+  deletion_protection     = true
+  skip_final_snapshot     = false
+  final_snapshot_identifier = "qfeed-prod-rds-final-snapshot"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-rds-postgres" })
+}

--- a/terraform/envs/prod/security_groups.tf
+++ b/terraform/envs/prod/security_groups.tf
@@ -1,0 +1,132 @@
+# ALB SG: HTTP:80 퍼블릭 오픈
+
+resource "aws_security_group" "alb" {
+  name        = "qfeed-prod-sg-alb"
+  description = "ALB - allow HTTP from anywhere"
+  vpc_id      = data.aws_vpc.prod.id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-sg-alb" })
+}
+
+# Backend EC2 SG: ALB에서 8080/8081
+
+resource "aws_security_group" "backend" {
+  name        = "qfeed-prod-sg-backend"
+  description = "Backend EC2 - allow 8080/8081 from ALB"
+  vpc_id      = data.aws_vpc.prod.id
+
+  ingress {
+    description     = "HTTP from ALB"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description     = "Actuator health check from ALB"
+    from_port       = 8081
+    to_port         = 8081
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-sg-backend" })
+}
+
+# AI EC2 SG: Backend에서 8000
+
+resource "aws_security_group" "ai" {
+  name        = "qfeed-prod-sg-ai"
+  description = "AI EC2 - allow 8000 from Backend SG"
+  vpc_id      = data.aws_vpc.prod.id
+
+  ingress {
+    description     = "FastAPI from Backend"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-sg-ai" })
+}
+
+# Redis EC2 SG: Backend에서 6379만
+
+resource "aws_security_group" "redis" {
+  name        = "qfeed-prod-sg-redis"
+  description = "Redis EC2 - allow 6379 from Backend SG"
+  vpc_id      = data.aws_vpc.prod.id
+
+  ingress {
+    description     = "Redis from Backend"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-sg-redis" })
+}
+
+# RDS SG: Backend에서 5432만
+
+resource "aws_security_group" "rds" {
+  name        = "qfeed-prod-sg-rds"
+  description = "RDS - allow 5432 from Backend SG"
+  vpc_id      = data.aws_vpc.prod.id
+
+  ingress {
+    description     = "PostgreSQL from Backend"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "qfeed-prod-sg-rds" })
+}

--- a/terraform/envs/prod/terraform.tfvars.example
+++ b/terraform/envs/prod/terraform.tfvars.example
@@ -1,0 +1,7 @@
+# terraform.tfvars.example
+# 실제 사용 시 terraform.tfvars로 복사 후 값을 채워주세요.
+# cp terraform.tfvars.example terraform.tfvars
+
+db_username = "your-db-username"
+
+alert_email = "your-email@example.com"

--- a/terraform/envs/prod/variables.tf
+++ b/terraform/envs/prod/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "ami_id" {
+  description = "Ubuntu 24.04 LTS ARM64 AMI"
+  type        = string
+  default     = "ami-066f9893a857529ea"
+}
+
+variable "key_pair_name" {
+  description = "EC2 키 페어 이름"
+  type        = string
+  default     = "qfeed-keypair-2"
+}
+
+variable "db_username" {
+  description = "RDS 마스터 유저"
+  type        = string
+}
+
+variable "alert_email" {
+  description = "알림 수신 이메일"
+  type        = string
+}


### PR DESCRIPTION
## Summary

Prod 환경 인프라를 Terraform으로 구성합니다 (`terraform/envs/prod/`, 12개 파일).

merge 후 `terraform apply` 실행 필요합니다.

## 관련 이슈

- closes #94 

## Dev → Prod 주요 변경

| 항목 | Dev | Prod |
|------|-----|------|
| VPC | 10.1.0.0/16 (dev VPC) | 10.0.0.0/16 (prod 전용 VPC) |
| EC2 위치 | Public Subnet | **Private Subnet** + NAT GW |
| Subnet 분리 | AZ 기준 (private_a/c) | **용도 기준** (Private-App / Private-Data) |
| Redis | docker-compose 내장 | **별도 EC2** (t4g.micro, AOF 활성화) |
| RDS | db.t4g.micro, 보호 없음 | **db.t4g.small**, deletion_protection + prevent_destroy |
| Backend ASG | 0/0/1 | **2/2/4** (최소 2대 상시) |
| SSH | 팀원 IP 제한 개방 | **완전 폐쇄** (SSM Session Manager only) |
| ALB SG | CloudFront prefix list | **0.0.0.0/0** (HTTPS는 후속 작업) |
| GitHub Actions | dev role, 전 브랜치 | **prod 전용 role**, main 브랜치만 |
| ECR ARN | `aws_ecr_repository.*.arn` | **`data.aws_caller_identity`** 동적 참조 |

## 설계 결정 상세

- [ADR 문서](https://www.notion.so/jinyshin/Prod-Terraform-3104cff7232680558d5ddecaf404eaa8?source=copy_link)

## 파일 목록

| 파일 | 설명 |
|------|------|
| `main.tf` | Backend S3 (`envs/prod/`), common_tags |
| `variables.tf` | 변수 선언 |
| `terraform.tfvars.example` | 변수 예시 |
| `data.tf` | VPC, subnet, OIDC, SSM, aws_caller_identity |
| `network.tf` | Public-c, Private-App-a, Private-Data-a/c, NAT GW |
| `security_groups.tf` | ALB, Backend, AI, Redis, RDS SG |
| `compute.tf` | BE/AI/Redis Launch Template + ASG |
| `alb.tf` | ALB + TG + Listener |
| `iam.tf` | EC2 roles (BE/AI/Redis) + GitHub Actions prod role |
| `rds.tf` | PostgreSQL, Single-AZ, 이중 삭제 보호 |
| `outputs.tf` | ALB DNS, RDS endpoint, NAT GW IP 등 |

## 후속 작업

- [x] `terraform apply` 실행 (merge 후)
- [x] SSM Parameter Store prod 값 등록
- [ ] Deploy 파일 작성 (`deploy/prod/`)
- [ ] HTTPS + 도메인 연결 (프론트엔드 팀원과 진행)
- [ ] ALB Access Log (모니터링 시스템 구축 시)

## Test Plan

- [x] `terraform plan` 성공 (49 resources, 0 errors)
- [x] `terraform apply` 후 리소스 생성 확인