### PR TITLE
fix: 컨테이너에게 로그 디렉토리 권한 부여

### DIFF
--- a/deploy/prod/ai/deploy.sh
+++ b/deploy/prod/ai/deploy.sh
@@ -40,7 +40,7 @@ docker rm "$CONTAINER_NAME" 2>/dev/null || true
 LOG_DIR="/var/log/qfeed/ai"
 if [ ! -d "$LOG_DIR" ] || [ ! -w "$LOG_DIR" ]; then
   sudo mkdir -p "$LOG_DIR"
-  sudo chown 1000:1000 "$LOG_DIR"
+  sudo chown 1000:101 "$LOG_DIR"
   sudo chmod 755 /var/log/qfeed "$LOG_DIR"
 fi
 


### PR DESCRIPTION
컨테이너(uid 1000)에게 로그 디렉토리 권한 부여

## 변경 내용

- prod deploy.sh에서 로그 디렉토리 생성 후 컨테이너가 파일을 생성할 수 있도록 권한 부여
- prod AI EC2 인스턴스에서는 수동으로 직접 진행

## 확인 사항

- [ ] 컨테이너의 uid가 맞는지

