### PR TITLE
[CL] Redis 별도 EC2 분리 — backend docker-compose에서 redis 제거

### DIFF
--- a/deploy/dev/backend/docker-compose.yml
+++ b/deploy/dev/backend/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     network_mode: host
     env_file: .env
     restart: unless-stopped
-    depends_on:
-      redis:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
       interval: 30s
@@ -18,24 +15,3 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-
-  redis:
-    image: redis:8-alpine
-    network_mode: host
-    command: redis-server --requirepass ${REDIS_PASSWORD} --bind 127.0.0.1
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    volumes:
-      - redis-data:/data
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-
-volumes:
-  redis-data:

--- a/deploy/prod/backend/docker-compose.yml
+++ b/deploy/prod/backend/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     network_mode: host
     env_file: .env
     restart: unless-stopped
-    depends_on:
-      redis:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
       interval: 30s
@@ -18,25 +15,3 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-
-  redis:
-    image: redis:8-alpine
-    network_mode: host
-    command: redis-server --requirepass ${REDIS_PASSWORD} --bind 127.0.0.1
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    volumes:
-      - redis-data:/data
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-
-volumes:
-  redis-data:
-


### PR DESCRIPTION
## Summary

- Dev/Prod backend `docker-compose.yml`에서 redis 사이드카 서비스를 제거
- Redis는 이제 별도 EC2(ASG)에서 독립적으로 운영됨
- backend는 SSM Parameter(`REDIS_HOST`)를 통해 외부 Redis EC2에 연결

## Background

기존에는 backend docker-compose 안에 redis가 사이드카로 포함되어 있었음.
Prod은 설계상 Redis 별도 EC2로 분리되어 있었으나, docker-compose는 아직 사이드카 구조였음.
Dev도 Prod과 동일한 구조로 맞추기 위해 양쪽 모두 redis 서비스를 제거함.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `deploy/dev/backend/docker-compose.yml` | redis 서비스, depends_on, redis-data 볼륨 제거 |
| `deploy/prod/backend/docker-compose.yml` | 동일 |

## 인프라 변경 (이 PR 범위 밖, 이미 완료)

- Dev Redis EC2: `qfeed-dev-asg-redis` (ASG 1/1/1, `10.1.5.250`)
- Prod Redis EC2: `qfeed-prod-asg-redis` (ASG 1/1/1, `10.0.18.17`)
- Prod Redis LT: SSM Agent snap 충돌 버그 수정 (v1 → v2), instance refresh 완료
- SSM `REDIS_HOST` 업데이트 완료 (Dev: `10.1.5.250`, Prod: `10.0.18.17`)

## Test plan

- [x] Dev backend 재배포 → 외부 Redis 연결 확인 (`REDIS_HOST=10.1.5.250`)
- [ ] Prod backend 재배포 → 외부 Redis 연결 확인 (`REDIS_HOST=10.0.18.17`)