### PR TITLE
fix: alloy 서버 listen address 0.0.0.0으로 변경

### DIFF
--- a/deploy/dev/backend/docker-compose.yml
+++ b/deploy/dev/backend/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     command:
       - "run"
       - "/etc/alloy/config.alloy"
-      - "--server.http.listen-addr=127.0.0.1:12345"
+      - "--server.http.listen-addr=0.0.0.0:12345"
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
       - /proc:/host/proc:ro


### PR DESCRIPTION
## 관련 이슈

- closes #

## 변경 내용

- alloy 서버 listen address 0.0.0.0으로 변경(cAdvisor exporter는 alloy 내부에 내장되어 있어 alloy 자신의 서버를 통해 메트릭 노출)

## 보안 체크

- [ ] 0.0.0.0으로 변경되었지만 보안 그룹에 12345번 포트가 노출되어 있지 않기 때문에 실질적 문제는 없음
