### PR TITLE
fix: /var/lib/docker 마운트 추가

### DIFF
--- a/deploy/dev/backend/docker-compose.yml
+++ b/deploy/dev/backend/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /dev/kmsg:/dev/kmsg:ro
+      - /var/lib/docker:/var/lib/docker:ro
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## 변경 내용

- /var/lib/docker 마운트 추가(컨테이너 레이어 정보를 읽지 못하는 문제 해결)

