### PR TITLE
fix: tts base url 환경 변수 주입

### DIFF
--- a/deploy/dev/ai/deploy.sh
+++ b/deploy/dev/ai/deploy.sh
@@ -27,6 +27,7 @@ echo "SSM 파라미터 조회 중..."
 
 GPU_STT_URL=$(get_ssm "gpu-stt-url")
 GPU_LLM_URL=$(get_ssm "gpu-llm-url")
+ELEVENLABS_BASE_URL=$(get_ssm "elevenlabs-base-url")
 
 echo "SSM 파라미터 조회 완료 (2개)"
 
@@ -44,6 +45,7 @@ AWS_PARAMETER_STORE_PATH=${SSM_PREFIX}
 # AI Service
 GPU_STT_URL=${GPU_STT_URL}
 GPU_LLM_URL=${GPU_LLM_URL}
+ELEVENLABS_BASE_URL=${ELVENLABS_BASE_URL}
 EOF
 
 chmod 600 "$ENV_FILE"


### PR DESCRIPTION
## 변경 내용

- tts base url 하드코딩 방식에서 환경 변수 주입 방식으로 변경, 해당 base url을 ssm으로 가져와서 .env 파일에 주입
